### PR TITLE
CRYPT-2: Optimize Neptune for to use GPUs

### DIFF
--- a/src/mining/gpu_miner.rs
+++ b/src/mining/gpu_miner.rs
@@ -703,10 +703,14 @@ impl GpuMiner {
             // MI100 GPUs can handle larger batches
             let nonce_range = if self.device_name.contains("MI100") {
                 // MI100 has 120 compute units, can handle larger batches
-                5_000_000_000 // 5 billion nonces per kernel launch for MI100
+                // Adjusted for better performance with ROCm 6.2.3
+                10_000_000_000 // 10 billion nonces per kernel launch for MI100
             } else {
                 1_000_000_000 // 1 billion nonces for other GPUs
             };
+            
+            // Log the nonce range for debugging
+            info!("Using nonce range of {} for device: {}", nonce_range, self.device_name);
 
             // Create and launch kernel
             let kernel = MiningKernel::new(difficulty, nonce_start, nonce_range);


### PR DESCRIPTION
## Description
This PR fixes the GPU mining implementation to work properly with AMD MI100 GPUs running ROCm 6.2.3.

## Changes
1. Fixed compiler flags by removing unsupported flags:
   - `--amdgpu-sroa=0`
   - `--amdgpu-load-store-vectorizer=0`
   - `--amdgpu-enable-flat-scratch`

2. Added automatic filtering of problematic flags for ROCm 6.2.3

3. Improved error detection and reporting for better debugging

4. Optimized thread block size from 256 to 512 threads for MI100 GPUs

5. Increased nonce range from 5 billion to 10 billion per kernel launch for MI100 GPUs

6. Removed incompatible GPU kernel attributes that were causing compilation issues

7. Added better logging of thread configuration and nonce ranges

## Testing
These changes should fix the compilation errors seen in the logs and allow the GPU mining to work properly on AMD MI100 GPUs with ROCm 6.2.3.

Fixes [CRYPT-2](https://telnyx.atlassian.net/browse/CRYPT-2)

[CRYPT-2]: https://telnyx.atlassian.net/browse/CRYPT-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ